### PR TITLE
Add RTD pull request preview

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  jobs:
+    create_environment:
+      # uv config from https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-uv
+       - asdf plugin add uv
+       - asdf install uv latest
+       - asdf global uv latest
+       - uv venv $READTHEDOCS_VIRTUALENV_PATH
+    install:
+       - uv sync
+    build:
+      html:
+        - uv run python make.py
+        - mkdir -p $READTHEDOCS_OUTPUT/html/
+        - cp -r build/html/* $READTHEDOCS_OUTPUT/html/
+


### PR DESCRIPTION
This PR demonstrates a working build on RTD, with [preview output](https://safety-critical-rust-coding-guidelines--1.org.readthedocs.build/en/1/).

For automatic pull request previews you also need to toggle a setting in RTD:
<img width="631" alt="Screenshot 2025-04-16 at 14 14 41" src="https://github.com/user-attachments/assets/d7971790-e10e-43ec-85b5-4a73bd021821" />

To get this working on the main repo

1. Open a PR with the contents of `.readthedocs.yaml` in the main repo (now you can't move PR target?)
2. Sign up for a [Community RTD account](https://app.readthedocs.org/accounts/signup/)
3. Connect the RTD account with GitHub
4. Add the Guidelines repo to RTD, it'll pick up the config file
5. Toggle the PR build setting

And I'll delete the temporary Guidelines RTD account I used.

